### PR TITLE
Modmail Implementation, simple relay between user and mod channel

### DIFF
--- a/src/main/java/org/togetherjava/discordbot/BotMain.java
+++ b/src/main/java/org/togetherjava/discordbot/BotMain.java
@@ -10,6 +10,7 @@ import org.togetherjava.discordbot.cli.CliArgumentSpecification;
 import org.togetherjava.discordbot.cli.CliArgumentSpecification_Parser;
 import org.togetherjava.discordbot.commands.CommandListener;
 import org.togetherjava.discordbot.config.TjBotConfig;
+import org.togetherjava.discordbot.events.modmail.ModMailListener;
 import org.togetherjava.discordbot.util.Messages;
 
 public class BotMain {
@@ -30,10 +31,11 @@ public class BotMain {
     logger.info("Starting JDA");
     JDA jda = new JDABuilder(AccountType.BOT)
         .setToken(config.getAndDeleteBotToken())
-        .addEventListeners()
         .build()
         .awaitReady();
+    jda.addEventListener(new ModMailListener(jda, config));
     jda.addEventListener(new CommandListener(config, messages, jda));
+
     logger.info("Started JDA");
   }
 }

--- a/src/main/java/org/togetherjava/discordbot/commands/CommandListener.java
+++ b/src/main/java/org/togetherjava/discordbot/commands/CommandListener.java
@@ -10,6 +10,7 @@ import de.ialistannen.commandprocrastination.command.tree.CommandNode;
 import de.ialistannen.commandprocrastination.parsing.ParseException;
 import javax.annotation.Nonnull;
 import net.dv8tion.jda.api.JDA;
+import net.dv8tion.jda.api.entities.ChannelType;
 import net.dv8tion.jda.api.events.message.MessageReceivedEvent;
 import net.dv8tion.jda.api.hooks.ListenerAdapter;
 import org.togetherjava.discordbot.commands.CommandContext.JdaRequestContext;
@@ -42,9 +43,10 @@ public class CommandListener extends ListenerAdapter {
 
   @Override
   public void onMessageReceived(@Nonnull MessageReceivedEvent event) {
-    if (event.getAuthor().isBot()) {
+    if (event.getAuthor().isBot() || event.isFromType(ChannelType.PRIVATE)) {
       return;
     }
+
     String content = event.getMessage().getContentRaw();
     try {
       JdaRequestContext context = new JdaRequestContext(

--- a/src/main/java/org/togetherjava/discordbot/config/TjBotConfig.java
+++ b/src/main/java/org/togetherjava/discordbot/config/TjBotConfig.java
@@ -17,12 +17,14 @@ public class TjBotConfig {
   private List<String> prefixes;
   private String botToken;
   private CommandConfig commands;
+  private String moderationChannel;
 
   @JsonCreator
-  public TjBotConfig(List<String> prefixes, String botToken, CommandConfig commands) {
+  public TjBotConfig(List<String> prefixes, String botToken, String moderationChannel, CommandConfig commands) {
     this.prefixes = Objects.requireNonNull(prefixes, "prefixes can not be null!");
     this.botToken = Objects.requireNonNull(botToken, "botToken can not be null!");
     this.commands = Objects.requireNonNull(commands, "commands can not be null!");
+    this.moderationChannel = Objects.requireNonNull(moderationChannel, "channel can not be null!");
   }
 
   /**
@@ -42,6 +44,13 @@ public class TjBotConfig {
   public CommandConfig getCommands() {
     return commands;
   }
+
+  /**
+   * Returns the moderation channel for modmail.
+   *
+   * @return the moderation channel for modmail.
+   */
+  public String getModerationChannel() { return moderationChannel; }
 
   /**
    * Returns the token and deletes it from the config.

--- a/src/main/java/org/togetherjava/discordbot/events/modmail/ModMailListener.java
+++ b/src/main/java/org/togetherjava/discordbot/events/modmail/ModMailListener.java
@@ -22,7 +22,6 @@ public class ModMailListener extends ListenerAdapter {
             throw new IllegalArgumentException("Moderation channel is invalid, does not exist");
         }
         moderation = channels.get(0);
-
     }
 
     @Override
@@ -35,11 +34,14 @@ public class ModMailListener extends ListenerAdapter {
 
     @Override
     public void onGuildMessageReceived(@NonNull GuildMessageReceivedEvent event) {
+        if(!event.getMessage().getTextChannel().equals(moderation)){
+            return;
+        }
+
         List<Member> mentioned = event.getMessage().getMentionedMembers();
         if (!event.getAuthor().isBot() && !mentioned.isEmpty()) {
             mentioned.get(0).getUser().openPrivateChannel().queue((channel) ->
                     channel.sendMessage(event.getMessage()).queue());
         }
     }
-
 }

--- a/src/main/java/org/togetherjava/discordbot/events/modmail/ModMailListener.java
+++ b/src/main/java/org/togetherjava/discordbot/events/modmail/ModMailListener.java
@@ -1,0 +1,45 @@
+package org.togetherjava.discordbot.events.modmail;
+
+import lombok.NonNull;
+import net.dv8tion.jda.api.JDA;
+import net.dv8tion.jda.api.entities.Member;
+import net.dv8tion.jda.api.entities.TextChannel;
+import net.dv8tion.jda.api.events.message.guild.GuildMessageReceivedEvent;
+import net.dv8tion.jda.api.events.message.priv.PrivateMessageReceivedEvent;
+import net.dv8tion.jda.api.hooks.ListenerAdapter;
+import org.togetherjava.discordbot.config.TjBotConfig;
+import javax.annotation.Nonnull;
+import java.util.List;
+
+
+
+public class ModMailListener extends ListenerAdapter {
+    private TextChannel moderation;
+
+    public ModMailListener(JDA jda, TjBotConfig config) {
+        List<TextChannel> channels = jda.getTextChannelsByName(config.getModerationChannel(), false);
+        if(channels.isEmpty()){
+            throw new IllegalArgumentException("Moderation channel is invalid, does not exist");
+        }
+        moderation = channels.get(0);
+
+    }
+
+    @Override
+    public void onPrivateMessageReceived(@Nonnull PrivateMessageReceivedEvent event) {
+        if (!event.getAuthor().isBot()) {
+            String message = "<@" + event.getAuthor().getId() + ">: " + event.getMessage().getContentRaw();
+            moderation.sendMessage(message).queue();
+        }
+    }
+
+    @Override
+    public void onGuildMessageReceived(@NonNull GuildMessageReceivedEvent event) {
+        List<Member> mentioned = event.getMessage().getMentionedMembers();
+        if (!event.getAuthor().isBot() && !mentioned.isEmpty()) {
+            mentioned.get(0).getUser().openPrivateChannel().queue((channel) ->
+                    channel.sendMessage(event.getMessage()).queue());
+        }
+    }
+
+}

--- a/src/main/resources/sample-config.yml
+++ b/src/main/resources/sample-config.yml
@@ -4,9 +4,13 @@
 prefixes: ["!", "?"]
 botToken: "your token"
 
+# channel for modmail
+moderationChannel: "your channel"
+
 # Command settings
 commands:
   # Configuration for the free command
   free:
     # The regex used to detect help channels for the free command
     helpChannelRegex: ".*"
+


### PR DESCRIPTION
Simple implementation for modmail, might need some more security features to prevent abuse. Any private messages the bot receives are relayed to the moderation channel with a @Mention for the user (won't notify them if they're not in the channel, which they shouldn't be). To respond @Mention the user, and type your message.