### PR TITLE
Meta: Add docker support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,9 @@ target/
 out/
 *.iml
 
+# Docker files
+.docker
+
 # Created by https://www.gitignore.io/api/eclipse,visualstudiocode
 # Edit at https://www.gitignore.io/?templates=eclipse,visualstudiocode
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,24 @@
+FROM openjdk:11-slim
+LABEL "tjbot"="true"
+
+ARG USER_ID
+
+# The user id is injected at build time
+RUN useradd --uid $USER_ID tjbot
+
+# Expose the config dir
+VOLUME ["/home/tjbot/config"]
+
+# We should be able to place temp data in there
+# Not *strictly* needed though
+RUN chown -R tjbot:tjbot /home/tjbot
+
+USER tjbot
+
+WORKDIR /home/tjbot
+
+# Include backend files
+COPY TjBot.jar /home/tjbot/TjBot.jar
+
+# Execute the server, needs the path to the configuration file passed as an argument
+ENTRYPOINT ["java", "-jar", "/home/tjbot/TjBot.jar"]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,21 @@
+USER_ID ?= 1000
+
+build: target/TjBot.jar
+	echo "Build done!"
+
+target/TjBot.jar: $(shell find -type f -iname '*.java' -or -iname '*sql') pom.xml
+	mvn package
+
+clean:
+	rm -rf .docker
+	mvn clean
+
+.PHONY: clean
+
+.docker:
+	mkdir .docker
+
+build-docker: build .docker
+	cp target/TjBot.jar .docker
+	cp Dockerfile .docker
+	(cd .docker && sudo docker build -t tjbot --build-arg USER_ID=$(USER_ID) .)

--- a/README.md
+++ b/README.md
@@ -3,12 +3,25 @@
 ## About
 The intention of this bot is to make moderation easier and provide useful commands to manage the server.
 
+## Contributing
+Before you contribute to this Repository consider taking a look at the [CONTRIBUTING.md](https://github.com/Together-Java/TjBot/blob/master/CONTRIBUTING.md).
+
 ## Running the bot
 1. Copy `src/main/resources/sample-config.yml` and use it to structure your bot config.
 2. Start the bot with following arguments: `-c path/to/your/config` 
 
-## Contributing
-Before you contribute to this Repository consider taking a look at the [CONTRIBUTING.md](https://github.com/Together-Java/TjBot/blob/master/CONTRIBUTING.md).
+## Running the bot in docker
+### On Linux
+1. Run `make build-docker USER_ID=<your wanted user id>` to build the image
+2. Run the docker image. The `WORKDIR` of the image is `/home/tjbot/`.
+   ```sh
+   sudo docker run                          \ # Run it
+    --rm                                    \ # Delete it on exit
+    -it                                     \ # Wire up std in and out (for testing)
+    -v "your config dir:/home/tjbot/config" \ # Mount in your config dir
+    tjbot                                   \ # Name of the image
+    -c config/sample-config.yml             \ # See 'Running the bot', Step 2.
+   ```
 
 ## Notice
 Please keep your private bot token secret. **Do not include your bot token in any committed or pushed file.**

--- a/README.md
+++ b/README.md
@@ -12,7 +12,9 @@ Before you contribute to this Repository consider taking a look at the [CONTRIBU
 
 ## Running the bot in docker
 ### On Linux
-1. Run `make build-docker USER_ID=<your wanted user id>` to build the image
+1. Run `make build-docker USER_ID=<your wanted user id>` to build the image.
+   The user id is needed, as the container does not run as root and needs to read the
+   config file you mount in.
 2. Run the docker image. The `WORKDIR` of the image is `/home/tjbot/`.
    ```sh
    sudo docker run                          \ # Run it

--- a/pom.xml
+++ b/pom.xml
@@ -43,6 +43,14 @@
         </executions>
         <configuration>
           <finalName>${project.name}</finalName>
+          <transformers>
+            <transformer
+              implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+              <manifestEntries>
+                <Main-Class>org.togetherjava.discordbot.BotMain</Main-Class>
+              </manifestEntries>
+            </transformer>
+          </transformers>
         </configuration>
       </plugin>
     </plugins>


### PR DESCRIPTION
## About this PR

This PR adds a `Dockerfile` alongside a small `Makefile` that helps build it. The `Dockerfile` bootstraps a minimal environment to run the bot.

## References

#12 